### PR TITLE
Moving compile module to main project

### DIFF
--- a/src/R4Mvc/R4MvcPreCompileModule.cs
+++ b/src/R4Mvc/R4MvcPreCompileModule.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using Microsoft.Framework.Runtime;
-using R4Mvc;
-
-namespace R4MvcHostApp.Compiler.Preprocess
+﻿namespace R4MvcHostApp.Compiler.Preprocess
 {
-    public class R4MvcPreCompileModule : ICompileModule
+	using Microsoft.Framework.Runtime;
+	using R4Mvc;
+
+	public class R4MvcPreCompileModule : ICompileModule
     {
         public void BeforeCompile(IBeforeCompileContext context)
         {

--- a/src/R4Mvc/R4MvcPreCompileModule.cs
+++ b/src/R4Mvc/R4MvcPreCompileModule.cs
@@ -1,7 +1,6 @@
-﻿namespace R4MvcHostApp.Compiler.Preprocess
+﻿namespace R4Mvc
 {
 	using Microsoft.Framework.Runtime;
-	using R4Mvc;
 
 	public class R4MvcPreCompileModule : ICompileModule
     {
@@ -12,7 +11,6 @@
 
         public void AfterCompile(IAfterCompileContext context)
         {
-
         }
     }
 }

--- a/src/R4MvcHostApp/Compiler/Preprocess/R4MvcCompiler.cs
+++ b/src/R4MvcHostApp/Compiler/Preprocess/R4MvcCompiler.cs
@@ -1,0 +1,6 @@
+namespace R4MvcHostApp.Compiler.Preprocess
+{
+	public class R4MvcCompiler : R4MvcPreCompileModule
+	{
+	}
+}

--- a/src/R4MvcHostApp/Compiler/Preprocess/R4MvcCompiler.cs
+++ b/src/R4MvcHostApp/Compiler/Preprocess/R4MvcCompiler.cs
@@ -1,5 +1,7 @@
 namespace R4MvcHostApp.Compiler.Preprocess
 {
+	using R4Mvc;
+
 	public class R4MvcCompiler : R4MvcPreCompileModule
 	{
 	}


### PR DESCRIPTION
follows same pattern as Roslyn Compile Module, also leaves more flexibility to put code in compiler module without polluting target project including distinguishing between code that is generated ..ie the Generator class and code that is modified in the target project ie the ControllerRewriter