### PR TITLE
handle target project compile errors

### DIFF
--- a/src/R4Mvc/R4MVCCompilerModule.cs
+++ b/src/R4Mvc/R4MVCCompilerModule.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis;
+
 namespace R4Mvc
 {
 	using System;
@@ -39,6 +41,9 @@ namespace R4Mvc
 			var compiler = context.CSharpCompilation;
 			foreach (var tree in compiler.SyntaxTrees.Where(x => !x.FilePath.Equals(generatedFilePath)))
 			{
+				// if syntaxtree has errors, skip code generation
+				if (tree.GetDiagnostics().Any(x => x.Severity == DiagnosticSeverity.Error)) continue;
+
 				// this first part, finds all the controller classes, modifies them and saves the changes
 				var controllerRewriter = new ControllerRewriter(compiler);
 				var newNode = controllerRewriter.Visit(tree.GetRoot());


### PR DESCRIPTION
if controller syntaxtrees have compile errors, code generation cannot run against them. 

It might be safer to not run generation at all in this situation.