### PR TITLE
Set the version number in the appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,18 @@
-version: 1.0.0.{build}
-
 image: Visual Studio 2017
 
-configuration: Release
+environment:
+  productVersion: 1.0.0-alpha1
+  assemblyVersion: 1.0.0
+ 
+version: $(productVersion).{build}
 
 init:
-- ps: $Env:VersionSuffix = "CI." + $Env:APPVEYOR_BUILD_NUMBER
+- ps: $env:versionSuffix = "ci." + $env:APPVEYOR_BUILD_NUMBER
 - ps: dotnet --info
 
 build_script:
-- ps: dotnet restore -v Minimal
-- ps: dotnet build -c Release --version-suffix $Env:VersionSuffix
+- ps: dotnet restore -v minimal
+- ps: dotnet build -c release --version-suffix "$env:versionSuffix" -p:VersionPrefix=$env:productVersion -p:FileVersion="$env:assemblyVersion.$env:APPVEYOR_BUILD_NUMBER"
 
 artifacts:
 - path: '**\*.nupkg'

--- a/src/R4Mvc.Tools/R4Mvc.Tools.csproj
+++ b/src/R4Mvc.Tools/R4Mvc.Tools.csproj
@@ -5,9 +5,6 @@
     <TargetFramework>net462</TargetFramework>
     <PackageProjectUrl>https://github.com/T4MVC/R4MVC</PackageProjectUrl>
     <RepositoryUrl>https://github.com/artiomchi/R4MVC</RepositoryUrl>
-    <AssemblyVersion>0.6.0</AssemblyVersion>
-    <FileVersion>0.6.0</FileVersion>
-    <VersionPrefix>0.6.0</VersionPrefix>
     <IsTool>True</IsTool>
     <ContentTargetFolders>tools</ContentTargetFolders>
     <DevelopmentDependency>True</DevelopmentDependency>

--- a/src/R4Mvc/R4Mvc.csproj
+++ b/src/R4Mvc/R4Mvc.csproj
@@ -5,9 +5,6 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\R4Mvc.xml</DocumentationFile>
     <PackageProjectUrl>https://github.com/T4MVC/R4MVC</PackageProjectUrl>
     <RepositoryUrl>https://github.com/artiomchi/R4MVC</RepositoryUrl>
-    <AssemblyVersion>0.6.0</AssemblyVersion>
-    <FileVersion>0.6.0</FileVersion>
-    <VersionPrefix>0.6.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">


### PR DESCRIPTION
@artiomchi what are your thoughts on this change?

We can now set the version number in the `appveyor.yml` and it will update the App Veyor build number, the nuget package version and version numbers in the built DLLs.

This is in preparation for the next PR which will:
1. Only add the `-ci.{build number}` suffix for builds which don't come from `master`.
2. Push the `ci` nuget packages to MyGet.

Later I'll add a step which will push tags from `master` to nuget.org.