### PR TITLE
Suggesting a new build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,10 +31,25 @@ for:
 
 - branches:
     only:
-    - /release\/.*/
+    - /feature\/.*/
 
   build_script:
-  - ps: dotnet build -c $Env:CONFIGURATION --version-suffix ($Env:APPVEYOR_REPO_BRANCH.Substring(8) + "-" + $Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))
+  - ps: dotnet build -c $Env:CONFIGURATION --version-suffix ("ci-" + $Env:APPVEYOR_REPO_BRANCH.Substring(8) + "-" + $Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))
+
+  deploy:
+    provider: NuGet
+    server: https://www.myget.org/F/artiomchi/api/v2/package
+    symbol_server: https://www.myget.org/F/artiomchi/symbols/api/v2/package
+    api_key:
+      secure: WH4xm0AVvnPcLMdVfX6j1fy8dcW+8PzRXqWs4yguRNGXi5zSs/8ZKii/0Pcr8bDA
+    artifact: /.*\.nupkg/
+
+- branches:
+    only:
+    - /prerelease\/.*/
+
+  build_script:
+  - ps: dotnet build -c $Env:CONFIGURATION --version-suffix ($Env:APPVEYOR_REPO_BRANCH.Substring(11) + "-" + $Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))
 
   deploy:
     provider: NuGet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,52 @@ image: Visual Studio 2017
 configuration: Release
 
 init:
-- ps: $Env:VersionSuffix = "CI." + $Env:APPVEYOR_BUILD_NUMBER
 - ps: dotnet --info
 
-build_script:
+before_build:
 - ps: dotnet restore -v Minimal
-- ps: dotnet build -c Release --version-suffix $Env:VersionSuffix
+
+build_script:
+- ps: dotnet build -c $Env:CONFIGURATION --version-suffix ("ci-" + $Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))
 
 artifacts:
 - path: '**\*.nupkg'
+
+for:
+- branches:
+    only:
+    - develop
+
+  deploy:
+    provider: NuGet
+    server: https://www.myget.org/F/artiomchi/api/v2/package
+    symbol_server: https://www.myget.org/F/artiomchi/symbols/api/v2/package
+    api_key:
+      secure: WH4xm0AVvnPcLMdVfX6j1fy8dcW+8PzRXqWs4yguRNGXi5zSs/8ZKii/0Pcr8bDA
+    artifact: /.*\.nupkg/
+
+- branches:
+    only:
+    - /release\/.*/
+
+  build_script:
+  - ps: dotnet build -c $Env:CONFIGURATION --version-suffix ($Env:APPVEYOR_REPO_BRANCH.Substring(8) + "-" + $Env:APPVEYOR_BUILD_NUMBER.PadLeft(5, "0"))
+
+  deploy:
+    provider: NuGet
+    api_key:
+      secure: WH4xm0AVvnPcLMdVfX6j1fy8dcW+8PzRXqWs4yguRNGXi5zSs/8ZKii/0Pcr8bDA
+    artifact: /.*\.nupkg/
+
+- branches:
+    only:
+    - master
+
+  build_script:
+  - ps: dotnet build -c $Env:CONFIGURATION
+
+  deploy:
+    provider: NuGet
+    api_key:
+      secure: WH4xm0AVvnPcLMdVfX6j1fy8dcW+8PzRXqWs4yguRNGXi5zSs/8ZKii/0Pcr8bDA
+    artifact: /.*\.nupkg/


### PR DESCRIPTION
Hey @kevinkuszyk 

Seeing as you were quite busy, and trying to move things a bit forward, I thought to play around with the build script. Here's what I came up with to help move #49 along (a sort of alternative to #48)

Here's what the new build script provides:
- Better versioning. As much as I live SemVer 2.0, I decided to go back to 1.0, and use dash based versions numbers. To make sure they're ordered correctly, the build numbers will be padded to 5 digits (sort of what MS does with their build numbers)
- The main version number will be stored in a single property in the project (`VersionPrefix`). It has to be number based (i.e. Major.Minor.Patch), so that it's also used in the assembly and file version automatically. Final releases will use this field for the package version number. Any other branches (CI, alpha, beta, etc) will populate the version suffix, making them pre-release builds.
- Following Git Flow, the `master` branch will be used for final releases. Pushes to the master branch will not use the version suffix (e.g. version `1.0.1`), and will deploy successful builds to NuGet
- The `develop` branch will be the main dev branch in the project, replacing the current master one. Builds to this branch will get a ci version suffix (e.g. version `1.0.1-ci-00137`), and will be pushed to the MyGet for the latest bleeding edge builds
- There'a a simple way to deploy pre-release builds to the global NuGet repository - just use release path branches. For example, pushing to `release\alpha1` will get a alpha1 version suffix (e.g. version `1.0.1-alpha1-00137`) and will be pushed to the public NuGet repo

Main benefits to this is that we'll bump the version of the code after each major release. At which point new CI builds will automatically be for the next version, same once they get to alpha/beta stages. And once we're ready to go live, we just push to master, and it goes live.

MyGet will be used only for CI builds, while alpha/beta and final releases will be pushed to the main NuGet repo. 


If you think it's worth approving, I suggest we merge into the develop branch, rather than the master one (don't want to prematurely push a release build). 
You'd also have to populate the right API keys for MyGet and NuGet, and set the repository URL for MyGet.

We can populate the package descriptions and everything else in the csproj files.

Thoughts?