### PR TITLE
Custom wwwroot parameter

### DIFF
--- a/src/R4Mvc.Tools/Services/StaticFileGeneratorService.cs
+++ b/src/R4Mvc.Tools/Services/StaticFileGeneratorService.cs
@@ -34,7 +34,7 @@ namespace R4Mvc.Tools.Services
         }
 
         // This will eventually read the Startup class, to identify the location(s) of the static roots
-        public string GetStaticFilesPath(string projectRoot) => Path.Combine(projectRoot, "wwwroot");
+        public string GetStaticFilesPath(string projectRoot) => Path.Combine(projectRoot, _settings.wwwroot);
 
         public ClassDeclarationSyntax AddStaticFiles(ClassDeclarationSyntax parentClass, string path, IEnumerable<StaticFile> files)
         {

--- a/src/R4Mvc.Tools/Services/StaticFileGeneratorService.cs
+++ b/src/R4Mvc.Tools/Services/StaticFileGeneratorService.cs
@@ -24,7 +24,8 @@ namespace R4Mvc.Tools.Services
         public MemberDeclarationSyntax GenerateStaticFiles(string projectRoot)
         {
             var staticFilesRoot = GetStaticFilesPath(projectRoot);
-            var staticfiles = _staticFileLocators.SelectMany(x => x.Find(staticFilesRoot));
+            var staticfiles = _staticFileLocators.SelectMany(x => x.Find(staticFilesRoot))
+                .Where(r=> _settings.IncludeContainer(r.Container));
 
             var linksClass = SyntaxFactory.ClassDeclaration(_settings.LinksNamespace)
                 .WithModifiers(SyntaxKind.PublicKeyword, SyntaxKind.StaticKeyword, SyntaxKind.PartialKeyword)

--- a/src/R4Mvc.Tools/Settings.cs
+++ b/src/R4Mvc.Tools/Settings.cs
@@ -6,5 +6,6 @@
         public string R4MvcNamespace { get; set; } = "R4Mvc";
         public string LinksNamespace { get; set; } = "Links";
         public bool SplitIntoMultipleFiles { get; set; } = true;
+        public string wwwroot { get; set; } = "wwwroot";
     }
 }

--- a/src/R4Mvc.Tools/Settings.cs
+++ b/src/R4Mvc.Tools/Settings.cs
@@ -1,4 +1,6 @@
-﻿namespace R4Mvc.Tools
+﻿using System.Linq;
+
+namespace R4Mvc.Tools
 {
     public class Settings
     {
@@ -7,5 +9,17 @@
         public string LinksNamespace { get; set; } = "Links";
         public bool SplitIntoMultipleFiles { get; set; } = true;
         public string wwwroot { get; set; } = "wwwroot";
+        public string[] wwwrootInclude { get; set; }
+
+        internal bool IncludeContainer(string container)
+        {
+            return wwwrootInclude == null || wwwrootInclude.Any(i => Match(i, container));
+        }
+
+        bool Match(string current, string container)
+        {
+            return container.StartsWith(current, System.StringComparison.InvariantCultureIgnoreCase);
+        }
+
     }
 }


### PR DESCRIPTION
This addresses a scenario where you configured aspnetcore to have a different wwwroot folder  via WebHostBuilder.UseWebRoot api.
For example if you configure WebHostBuilder.UseWebRoot(".") then you can have the correct link generated with the folloing r4mvc.json :
{
  "wwwroot": ".",
  "wwwrootInclude": [ "wwwroot" ]
}

