### PR TITLE
Issue # 110: virtual keyword added to override method.

### DIFF
--- a/samples/AspNetSimple/Controllers/DebugControllerBase.cs
+++ b/samples/AspNetSimple/Controllers/DebugControllerBase.cs
@@ -6,5 +6,6 @@ namespace AspNetSimple.Controllers
     public abstract class DebugControllerBase : Controller
     {
         public IActionResult Debug() => throw new NotImplementedException();
+        public virtual IActionResult OverrideMe() => throw new NotImplementedException();
     }
 }

--- a/samples/AspNetSimple/Controllers/TestsController.cs
+++ b/samples/AspNetSimple/Controllers/TestsController.cs
@@ -52,5 +52,7 @@ namespace AspNetSimple.Controllers
 
         public virtual IActionResult LocalViewModel(ErrorViewModel model) => throw new NotImplementedException();
         public virtual IActionResult ExternalViewModel(TestViewModel model) => throw new NotImplementedException();
+
+        public override IActionResult OverrideMe() => throw new NotImplementedException();
     }
 }

--- a/samples/AspNetSimple/Controllers/TestsController.generated.cs
+++ b/samples/AspNetSimple/Controllers/TestsController.generated.cs
@@ -154,6 +154,7 @@ namespace AspNetSimple.Controllers
             public readonly string TaskApiCallTypedWithParams = "TaskApiCallTypedWithParams";
             public readonly string LocalViewModel = "LocalViewModel";
             public readonly string ExternalViewModel = "ExternalViewModel";
+            public readonly string OverrideMe = "OverrideMe";
         }
 
         [GeneratedCode("R4Mvc", "1.0"), DebuggerNonUserCode]
@@ -187,6 +188,7 @@ namespace AspNetSimple.Controllers
             public const string TaskApiCallTypedWithParams = "TaskApiCallTypedWithParams";
             public const string LocalViewModel = "LocalViewModel";
             public const string ExternalViewModel = "ExternalViewModel";
+            public const string OverrideMe = "OverrideMe";
         }
 
         [GeneratedCode("R4Mvc", "1.0"), DebuggerNonUserCode]
@@ -457,6 +459,16 @@ namespace AspNetSimple.Controllers
             var callInfo = new R4Mvc_Microsoft_AspNetCore_Mvc_ActionResult(Area, Name, ActionNames.ExternalViewModel);
             ModelUnbinderHelpers.AddRouteValues(callInfo.RouteValueDictionary, "model", model);
             ExternalViewModelOverride(callInfo, model);
+            return callInfo;
+        }
+
+        [NonAction]
+        partial void OverrideMeOverride(R4Mvc_Microsoft_AspNetCore_Mvc_ActionResult callInfo);
+        [NonAction]
+        public override Microsoft.AspNetCore.Mvc.IActionResult OverrideMe()
+        {
+            var callInfo = new R4Mvc_Microsoft_AspNetCore_Mvc_ActionResult(Area, Name, ActionNames.OverrideMe);
+            OverrideMeOverride(callInfo);
             return callInfo;
         }
     }

--- a/src/R4Mvc.Tools/ControllerRewriter.cs
+++ b/src/R4Mvc.Tools/ControllerRewriter.cs
@@ -56,7 +56,7 @@ namespace R4Mvc.Tools
             node = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
 
             // only public methods not marked as virtual
-            if (node.Modifiers.Any(SyntaxKind.PublicKeyword) && !node.Modifiers.Any(SyntaxKind.VirtualKeyword))
+            if (node.Modifiers.Any(SyntaxKind.PublicKeyword) && !node.Modifiers.Any(m => m.IsKind(SyntaxKind.VirtualKeyword) || m.IsKind(SyntaxKind.OverrideKeyword)))
             {
                 var symbol = _compiler.GetSemanticModel(node.SyntaxTree).GetDeclaredSymbol(node);
                 if (ControllerShouldBeProcessed(symbol.ContainingType) && symbol.IsMvcAction() && symbol.IsNotR4MvcExcluded())


### PR DESCRIPTION
Fix for Issue #110 I reported a few days ago. Very simple. Just have the ControllerRewriter not add the virtual keyword if the action method is already marked as override.