### PR TITLE
Add `[NonHandler]` as well as `[NonAction]` to handler methods

### DIFF
--- a/src/R4Mvc.Tools/CodeGen/CodeFileBuilder.cs
+++ b/src/R4Mvc.Tools/CodeGen/CodeFileBuilder.cs
@@ -35,6 +35,7 @@ namespace R4Mvc.Tools.CodeGen
                 "System.Diagnostics",
                 "System.Threading.Tasks",
                 "Microsoft.AspNetCore.Mvc",
+                "Microsoft.AspNetCore.Mvc.RazorPages",
                 "Microsoft.AspNetCore.Routing",
                 settings.R4MvcNamespace,
             };

--- a/src/R4Mvc.Tools/CodeGen/MethodBuilder.cs
+++ b/src/R4Mvc.Tools/CodeGen/MethodBuilder.cs
@@ -15,7 +15,7 @@ namespace R4Mvc.Tools.CodeGen
         private IList<ParameterSyntax> _parameters = new List<ParameterSyntax>();
         private BlockSyntax _bodyBlock;
         private ExpressionSyntax _expressionBodySyntax;
-        private bool _useGeneratedAttributes = false, _useNonActionAttribute = false, _noBody = false;
+        private bool _useGeneratedAttributes = false, _useNonActionAttribute = false, _useNonHandlerAttribute = false, _noBody = false;
 
         protected MethodBuilder() { }
         public MethodBuilder(string name, string returnType = null)
@@ -41,6 +41,12 @@ namespace R4Mvc.Tools.CodeGen
         public MethodBuilder WithNonActionAttribute()
         {
             _useNonActionAttribute = true;
+            return this;
+        }
+
+        public MethodBuilder WithNonHandlerAttribute()
+        {
+            _useNonHandlerAttribute = true;
             return this;
         }
 
@@ -92,6 +98,8 @@ namespace R4Mvc.Tools.CodeGen
                         method = method.AddParameterListParameters(_parameters.ToArray());
                     if (_useNonActionAttribute)
                         method = SyntaxNodeHelpers.WithNonActionAttribute(method);
+                    if (_useNonHandlerAttribute)
+                        method = SyntaxNodeHelpers.WithNonHandlerAttribute(method);
                     if (_useGeneratedAttributes)
                         method = method.AddAttributeLists(SyntaxNodeHelpers.GeneratedNonUserCodeAttributeList());
 

--- a/src/R4Mvc.Tools/Extensions/SyntaxNodeHelpers.cs
+++ b/src/R4Mvc.Tools/Extensions/SyntaxNodeHelpers.cs
@@ -142,6 +142,9 @@ namespace R4Mvc.Tools.Extensions
         public static MethodDeclarationSyntax WithNonActionAttribute(this MethodDeclarationSyntax node)
             => node.AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(IdentifierName("NonAction")))));
 
+        public static MethodDeclarationSyntax WithNonHandlerAttribute(this MethodDeclarationSyntax node)
+            => node.AddAttributeLists(AttributeList(SingletonSeparatedList(Attribute(IdentifierName("NonHandler")))));
+
         public static FieldDeclarationSyntax WithGeneratedAttribute(this FieldDeclarationSyntax node)
             => node.AddAttributeLists(AttributeList(SingletonSeparatedList(CreateGeneratedCodeAttribute())));
 

--- a/src/R4Mvc.Tools/Services/PageGeneratorService.cs
+++ b/src/R4Mvc.Tools/Services/PageGeneratorService.cs
@@ -290,7 +290,7 @@ namespace R4Mvc.Tools.Services
                      */
                     .WithMethod(method.Key, "IActionResult", m => m
                         .WithModifiers(SyntaxKind.PublicKeyword, SyntaxKind.VirtualKeyword)
-                        .WithNonActionAttribute()
+                        .WithNonHandlerAttribute()
                         .WithGeneratedNonUserCodeAttributes()
                         .WithBody(b => b
                             .ReturnNewObject(Constants.PageActionResultClass,
@@ -347,17 +347,17 @@ namespace R4Mvc.Tools.Services
                     handlerKey = "null";
 
                 classBuilder
-                    /* [NonAction]
+                    /* [NonHandler]
                      * partial void {action}Override({ActionResultType} callInfo, [� params]);
                      */
                     .WithMethod(method.Name + overrideMethodSuffix, null, m => m
                         .WithModifiers(SyntaxKind.PartialKeyword)
-                        .WithNonActionAttribute()
+                        .WithNonHandlerAttribute()
                         .WithParameter("callInfo", callInfoType)
                         .ForEach(method.Parameters, (m2, p) => m2
                             .WithParameter(p.Name, p.Type.ToString()))
                         .WithNoBody())
-                    /* [NonAction]
+                    /* [NonHandler]
                      * public overrive {ActionResultType} {action}([� params])
                      * {
                      *  var callInfo = new R4Mvc_Microsoft_AspNetCore_Mvc_RazorPages_ActionResult(Name, HandlerNames.{Handler});
@@ -368,7 +368,7 @@ namespace R4Mvc.Tools.Services
                      */
                     .WithMethod(method.Name, method.ReturnType.ToString(), m => m
                         .WithModifiers(SyntaxKind.PublicKeyword, SyntaxKind.OverrideKeyword)
-                        .WithNonActionAttribute()
+                        .WithNonHandlerAttribute()
                         .ForEach(method.Parameters, (m2, p) => m2
                             .WithParameter(p.Name, p.Type.ToString()))
                         .WithBody(b => b

--- a/test/R4Mvc.Test/CodeGen/MethodBuilderTests.cs
+++ b/test/R4Mvc.Test/CodeGen/MethodBuilderTests.cs
@@ -62,6 +62,16 @@ namespace R4Mvc.Test.CodeGen
             Assert.Equal("[NonAction]voidMethodName(){}", result.ToString());
         }
 
+        [Fact]
+        public void Method_NonHandler()
+        {
+            var result = new MethodBuilder("MethodName")
+                .WithNonHandlerAttribute()
+                .Build();
+
+            Assert.Equal("[NonHandler]voidMethodName(){}", result.ToString());
+        }
+
         [Theory]
         [InlineData("name", "string")]
         [InlineData("name", "string", true)]


### PR DESCRIPTION
Fixes #137 so we don't get `InvalidOperationException: Multiple handlers matched. ...`