### PR TITLE
add setting ExcludeControllers to exclude controllers

### DIFF
--- a/src/R4Mvc.Tools/Commands/GenerateCommand.cs
+++ b/src/R4Mvc.Tools/Commands/GenerateCommand.cs
@@ -109,7 +109,14 @@ project-path:
                 Console.WriteLine();
 
                 // Analyse the controllers in the project (updating them to be partial), as well as locate all the view files
-                var controllers = _controllerRewriter.RewriteControllers(compilation);
+
+                var controllers = new List<ControllerDefinition>();
+
+                if (_settings.ExcludeControllers == false)
+                {
+                    controllers.AddRange(_controllerRewriter.RewriteControllers(compilation));
+                }
+
                 var allViewFiles = _viewLocators.SelectMany(x => x.Find(projectRoot));
 
                 // Assign view files to controllers

--- a/src/R4Mvc.Tools/Settings.cs
+++ b/src/R4Mvc.Tools/Settings.cs
@@ -12,6 +12,7 @@
         public bool SplitIntoMultipleFiles { get; set; } = true;
         public bool SplitViewOnlyPagesIntoMultipleFiles { get; set; } = true;
         public string StaticFilesPath { get; set; } = "wwwroot";
+        public bool ExcludeControllers { get; set; }
         public string[] ExcludedStaticFileExtensions { get; set; }
         public string[] ReferencedNamespaces { get; set; }
         public string[] PragmaCodes { get; set; }


### PR DESCRIPTION
Add a setting ExcludeControllers, as an alternative way of excluding all controllers, as an alternative to using the [R4MVCExclude] attribute. 

In our case we only leverage the view helpers and would like avoid modifying the controllers.